### PR TITLE
Add numRnd form value for captcha

### DIFF
--- a/SunatScraper.Core/Services/SunatClient.cs
+++ b/SunatScraper.Core/Services/SunatClient.cs
@@ -19,7 +19,10 @@ public sealed class SunatClient
     public static SunatClient Create(string? redis=null){
         var handler=new HttpClientHandler{CookieContainer=new CookieContainer(),AutomaticDecompression=DecompressionMethods.All};
         var http=new HttpClient(handler){BaseAddress=new Uri("https://e-consultaruc.sunat.gob.pe/")};
-        http.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0");
+        http.DefaultRequestHeaders.UserAgent.ParseAdd(
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+            "AppleWebKit/537.36 (KHTML, like Gecko) " +
+            "Chrome/122.0.0.0 Safari/537.36");
         http.DefaultRequestHeaders.Accept.ParseAdd("text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
         http.DefaultRequestHeaders.Add("Upgrade-Insecure-Requests","1");
         http.DefaultRequestHeaders.AcceptLanguage.ParseAdd("es-PE,es;q=0.9");
@@ -52,6 +55,7 @@ public sealed class SunatClient
         await _http.GetAsync("cl-ti-itmrconsruc/FrameCriterioBusquedaWeb.jsp");
         form["token"]=_sec.GenerateToken();
         form["codigo"]=await _sec.SolveCaptchaAsync();
+        form["numRnd"]=_sec.LastRandom.ToString();
         form["contexto"]="ti-it";form["modo"]="1";
         using var req=new HttpRequestMessage(HttpMethod.Post,"cl-ti-itmrconsruc/jcrS00Alias"){
             Content=new FormUrlEncodedContent(form)

--- a/SunatScraper.Core/Services/SunatSecurity.cs
+++ b/SunatScraper.Core/Services/SunatSecurity.cs
@@ -5,6 +5,7 @@ using Tesseract;
 public class SunatSecurity
 {
     private readonly HttpClient _http;
+    public int LastRandom { get; private set; }
     public SunatSecurity(HttpClient h)=>_http=h;
     public string GenerateToken(int len=52){
         var sb=new System.Text.StringBuilder(len);
@@ -23,6 +24,7 @@ public class SunatSecurity
     }
     public async Task<string> SolveCaptchaAsync(){
         int rnd=Random.Shared.Next(1,9999);
+        LastRandom = rnd;
         var req=new HttpRequestMessage(HttpMethod.Get,$"/cl-ti-itmrconsruc/captcha?accion=image&nmagic={rnd}");
         req.Headers.Referrer=new Uri(_http.BaseAddress!,"cl-ti-itmrconsruc/FrameCriterioBusquedaWeb.jsp");
         req.Headers.Accept.ParseAdd("image/avif,image/webp,image/apng,image/*,*/*;q=0.8");


### PR DESCRIPTION
## Summary
- store captcha random value in `SunatSecurity`
- send `numRnd` with form data when querying SUNAT
- use a more realistic User-Agent when making requests

## Testing
- `dotnet build SunatScraper.Api/SunatScraper.Api.csproj --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68521b16e22c832caae7961fc952d1c2