### PR TITLE
Add DNI search list endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ La API quedará disponible en `http://localhost:5000/`.
 - `GET /` – Comprobación de funcionamiento.
 - `GET /ruc/{ruc}` – Consulta por número de RUC.
 - `GET /doc/{tipo}/{numero}` – Búsqueda por tipo y número de documento.
+- `GET /doc/{tipo}/{numero}/lista` – Devuelve la "Relación de contribuyentes" para el documento indicado.
 - `GET /rs?q={razon social}` – Búsqueda por nombre o razón social.
 
 ## 💻 Ejemplos de uso
@@ -34,6 +35,10 @@ curl http://localhost:5000/ruc/20100113774
 ### Búsqueda por documento (DNI)
 ```bash
 curl http://localhost:5000/doc/1/73870570
+```
+### Obtener lista de resultados para un documento
+```bash
+curl http://localhost:5000/doc/1/73870570/lista
 ```
 
 ### Búsqueda por razón social

--- a/SunatScraper.Api/Program.cs
+++ b/SunatScraper.Api/Program.cs
@@ -10,5 +10,6 @@ var app=b.Build();
 app.MapGet("/",()=> "SUNAT RUC API ok");
 app.MapGet("/ruc/{r}",async([FromServices]SunatClient s,string r)=>Results.Json(await s.ByRucAsync(r)));
 app.MapGet("/doc/{t}/{n}",async([FromServices]SunatClient s,string t,string n)=>Results.Json(await s.ByDocumentoAsync(t,n)));
+app.MapGet("/doc/{t}/{n}/lista",async([FromServices]SunatClient s,string t,string n)=>Results.Json(await s.SearchDocumentoAsync(t,n)));
 app.MapGet("/rs",async([FromServices]SunatClient s,[FromQuery]string q)=>Results.Json(await s.ByRazonAsync(q)));
 app.Run();

--- a/SunatScraper.Core/Models/RucInfo.cs
+++ b/SunatScraper.Core/Models/RucInfo.cs
@@ -5,7 +5,8 @@ public sealed record RucInfo(
     string? RazonSocial,
     string? Estado,
     string? Condicion,
-    string? Direccion)
+    string? Direccion,
+    string? Ubicacion = null)
 {
     public string ToJson() => JsonSerializer.Serialize(this,
         new JsonSerializerOptions { WriteIndented = true });

--- a/SunatScraper.Core/Models/SearchResultItem.cs
+++ b/SunatScraper.Core/Models/SearchResultItem.cs
@@ -1,0 +1,10 @@
+namespace SunatScraper.Core.Models;
+using System.Text.Json;
+public sealed record SearchResultItem(
+    string? Ruc,
+    string? RazonSocial,
+    string? Ubicacion,
+    string? Estado)
+{
+    public string ToJson() => JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = true });
+}


### PR DESCRIPTION
## Summary
- include new `SearchResultItem` model
- add `Ubicacion` field to `RucInfo`
- parse `Relación de contribuyentes` via `ParseList`
- extend `SunatClient` with `SearchDocumentoAsync`
- expose new `/doc/{tipo}/{numero}/lista` endpoint
- document new endpoint

## Testing
- `dotnet build SunatScraper.Api/SunatScraper.Api.csproj --no-restore`
- `dotnet build SunatScraper.Grpc/SunatScraper.Grpc.csproj`

------
https://chatgpt.com/codex/tasks/task_e_685281f374c4832cae6414f03719fdf1