### PR TITLE
Add document type to RUC info

### DIFF
--- a/SunatScraper.Core/Models/RucInfo.cs
+++ b/SunatScraper.Core/Models/RucInfo.cs
@@ -6,7 +6,8 @@ public sealed record RucInfo(
     string? Estado,
     string? Condicion,
     string? Direccion,
-    string? Ubicacion = null)
+    string? Ubicacion = null,
+    string? Documento = null)
 {
     public string ToJson() => JsonSerializer.Serialize(this,
         new JsonSerializerOptions { WriteIndented = true });


### PR DESCRIPTION
## Summary
- extend `RucInfo` with new `Documento` property
- improve HTML parser to handle RUC pages with `div.list-group-item`
- extract "Tipo de Documento" line and return it in the API
- fix location parsing for document search list

## Testing
- `dotnet build SunatScraper.Api/SunatScraper.Api.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6852880e38b4832c86d875ec4fb870f6