### PR TITLE
Support contribuyente field

### DIFF
--- a/SunatScraper.Api/Program.cs
+++ b/SunatScraper.Api/Program.cs
@@ -1,10 +1,14 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http.Json;
+using System.Text.Json.Serialization;
 using SunatScraper.Core.Services;
 using Serilog;
 
 var b=WebApplication.CreateBuilder(args);
 b.Host.UseSerilog((ctx,lc)=>lc.WriteTo.Console());
 b.Services.AddSingleton(_=>SunatClient.Create(b.Configuration["Redis"]));
+b.Services.ConfigureHttpJsonOptions(o=>
+    o.SerializerOptions.DefaultIgnoreCondition=JsonIgnoreCondition.WhenWritingNull);
 var app=b.Build();
 
 app.MapGet("/",()=> "SUNAT RUC API ok");

--- a/SunatScraper.Core/Models/RucInfo.cs
+++ b/SunatScraper.Core/Models/RucInfo.cs
@@ -1,5 +1,6 @@
 namespace SunatScraper.Core.Models;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 public sealed record RucInfo(
     string? Ruc,
     string? RazonSocial,
@@ -7,8 +8,12 @@ public sealed record RucInfo(
     string? Condicion,
     string? Direccion,
     string? Ubicacion = null,
-    string? Documento = null)
+    [property: JsonPropertyName("documento")] string? Documento = null,
+    [property: JsonPropertyName("contribuyente")] string? Contribuyente = null)
 {
     public string ToJson() => JsonSerializer.Serialize(this,
-        new JsonSerializerOptions { WriteIndented = true });
+        new JsonSerializerOptions {
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        });
 }

--- a/SunatScraper.Core/Services/RucPageParser.cs
+++ b/SunatScraper.Core/Services/RucPageParser.cs
@@ -55,11 +55,17 @@ internal static class RucPageParser
         string? ubic = GetValue(map,"Ubicación");
         razon=GetValue(map,"Razón") ?? GetValue(map,"Nombre") ?? razon;
         var docLine=GetValue(map,"Tipo de Documento");
-        string? documento=null;
+        var contribLine=GetValue(map,"Tipo Contribuyente");
+        string? documento=null,contribuyente=null;
         if(docLine!=null)
         {
             int dash=docLine.IndexOf('-');
             documento=(dash>0?docLine[..dash]:docLine).Trim();
+        }
+        if(contribLine!=null)
+        {
+            int dash=contribLine.IndexOf('-');
+            contribuyente=(dash>0?contribLine[..dash]:contribLine).Trim();
         }
 
         // Fallback using regular expressions when values are missing
@@ -95,6 +101,16 @@ internal static class RucPageParser
                 documento=(dash>0?d[..dash]:d).Trim();
             }
         }
+        if(contribuyente==null)
+        {
+            var m=Regex.Match(plain,@"Tipo Contribuyente\s*:\s*([^\n]+)",RegexOptions.IgnoreCase);
+            if(m.Success)
+            {
+                var d=m.Groups[1].Value.Trim();
+                int dash=d.IndexOf('-');
+                contribuyente=(dash>0?d[..dash]:d).Trim();
+            }
+        }
 
         return new RucInfo(
             ruc,
@@ -103,7 +119,8 @@ internal static class RucPageParser
             condicion,
             direccion,
             ubic,
-            documento);
+            documento,
+            contribuyente);
     }
 
     internal static IEnumerable<SearchResultItem> ParseList(string html)


### PR DESCRIPTION
## Summary
- parse "Tipo Contribuyente" field when present
- expose a `contribuyente` property in the JSON output
- ignore null fields in JSON serialization

## Testing
- `dotnet build SunatScraper.Api/SunatScraper.Api.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685295c87758832c9cd1de9e12cfcfda