### PR TITLE
Improve DocumentPageParser HTML handling

### DIFF
--- a/SunatScraper.Core/Services/DocumentPageParser.cs
+++ b/SunatScraper.Core/Services/DocumentPageParser.cs
@@ -1,38 +1,141 @@
 namespace SunatScraper.Core.Services;
+using HtmlAgilityPack;
 using SunatScraper.Core.Models;
-using System.Collections.Generic;
 using System.Net;
+using System.Linq;
+using System;
+using System.Text;
 using System.Text.RegularExpressions;
+using System.Globalization;
 
 internal static class DocumentPageParser
 {
+    static string Normalize(string s)
+    {
+        var f = s.Normalize(NormalizationForm.FormD);
+        Span<char> buf = stackalloc char[f.Length];
+        int idx = 0;
+        foreach (var c in f)
+            if (CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)
+                buf[idx++] = char.ToLowerInvariant(c);
+        return new string(buf[..idx]);
+    }
+
+    static string? GetValue(IDictionary<string, string> map, string label)
+    {
+        var normLabel = Normalize(label);
+        foreach (var (k, v) in map)
+        {
+            if (k.Contains(label, StringComparison.OrdinalIgnoreCase) ||
+                Normalize(k).Contains(normLabel, StringComparison.OrdinalIgnoreCase))
+                return v;
+        }
+        return null;
+    }
+
     internal static RucInfo Parse(string html)
     {
-        var plain = WebUtility.HtmlDecode(html);
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+        var map = new Dictionary<string, string>();
+        foreach (var td in doc.DocumentNode.SelectNodes("//td[@class='bgn']") ?? Enumerable.Empty<HtmlNode>())
+        {
+            var key = td.InnerText.Trim();
+            var val = td.NextSibling;
+            while (val is { Name: not "td" }) val = val.NextSibling;
+            map[key] = WebUtility.HtmlDecode(val?.InnerText.Trim() ?? "");
+        }
+        if (map.Count == 0)
+        {
+            foreach (var node in doc.DocumentNode.SelectNodes("//div[contains(@class,'list-group-item')]") ?? Enumerable.Empty<HtmlNode>())
+            {
+                var text = WebUtility.HtmlDecode(node.InnerText.Trim());
+                int idx = text.IndexOf(':');
+                if (idx > 0)
+                {
+                    var key = text[..idx].Trim();
+                    var val = text[(idx + 1)..].Trim();
+                    map[key] = val;
+                }
+            }
+        }
 
-        string? ruc = Regex.Match(plain, @"\b(\d{11})\b").Groups[1].Value;
-        if (string.IsNullOrWhiteSpace(ruc)) ruc = null;
+        var rucLine = GetValue(map, "RUC");
+        string? ruc = null, razon = null;
+        if (rucLine != null)
+        {
+            var m = Regex.Match(rucLine, @"\d{11}");
+            if (m.Success)
+            {
+                ruc = m.Value;
+                var after = rucLine[(m.Index + m.Length)..].Trim();
+                if (after.StartsWith("-")) after = after[1..].Trim();
+                razon = after.Length > 0 ? after : null;
+            }
+            else ruc = rucLine.Trim();
+        }
 
-        string? razon = Regex.Match(plain, @"\b\d{11}\s*-\s*([^\n]+)").Groups[1].Value.Trim();
-        if (string.IsNullOrWhiteSpace(razon)) razon = null;
+        string? estado = GetValue(map, "Estado");
+        string? condicion = GetValue(map, "Condición");
+        string? direccion = GetValue(map, "Dirección") ?? GetValue(map, "Domicilio");
+        string? ubic = GetValue(map, "Ubicación");
+        razon = GetValue(map, "Razón") ?? GetValue(map, "Nombre") ?? razon;
+        var docLine = GetValue(map, "Tipo de Documento");
+        var contribLine = GetValue(map, "Tipo Contribuyente");
+        string? documento = null, contribuyente = null;
+        if (docLine != null)
+        {
+            int dash = docLine.IndexOf('-');
+            documento = (dash > 0 ? docLine[..dash] : docLine).Trim();
+        }
+        if (contribLine != null)
+        {
+            int dash = contribLine.IndexOf('-');
+            contribuyente = (dash > 0 ? contribLine[..dash] : contribLine).Trim();
+        }
 
-        string? estado = Regex.Match(plain, @"Estado\s*:\s*([^\n]+)", RegexOptions.IgnoreCase).Groups[1].Value.Trim();
+        var plain = WebUtility.HtmlDecode(doc.DocumentNode.InnerText);
+        if (string.IsNullOrWhiteSpace(ruc))
+        {
+            var m = Regex.Match(plain, @"\b(\d{11})\b");
+            if (m.Success) ruc = m.Groups[1].Value;
+        }
+        if (string.IsNullOrWhiteSpace(razon) || razon == "-")
+        {
+            var m = Regex.Match(plain, @"\b\d{11}\s*-\s*([^\n]+)");
+            if (m.Success) razon = m.Groups[1].Value.Trim();
+        }
+        estado ??= Regex.Match(plain, @"Estado\s*:\s*([^\n]+)", RegexOptions.IgnoreCase).Groups[1].Value.Trim();
         if (string.IsNullOrWhiteSpace(estado)) estado = null;
-
-        string? condicion = Regex.Match(plain, @"Condici(?:\u00f3|o)n\s*:\s*([^\n]+)", RegexOptions.IgnoreCase).Groups[1].Value.Trim();
+        condicion ??= Regex.Match(plain, @"Condici(?:\u00f3|o)n\s*:\s*([^\n]+)", RegexOptions.IgnoreCase).Groups[1].Value.Trim();
         if (string.IsNullOrWhiteSpace(condicion)) condicion = null;
-
-        string? direccion = Regex.Match(plain, @"Direcci(?:\u00f3|o)n\s*:\s*([^\n]+)", RegexOptions.IgnoreCase).Groups[1].Value.Trim();
-        if (string.IsNullOrWhiteSpace(direccion)) direccion = null;
-
-        string? ubic = Regex.Match(plain, @"Ubicaci(?:\u00f3|o)n\s*:\s*([^\n]+)", RegexOptions.IgnoreCase).Groups[1].Value.Trim();
+        if (string.IsNullOrWhiteSpace(direccion))
+        {
+            var m = Regex.Match(plain, @"Direcci(?:\u00f3|o)n\s*:\s*([^\n]+)", RegexOptions.IgnoreCase);
+            if (m.Success) direccion = m.Groups[1].Value.Trim();
+        }
+        ubic ??= Regex.Match(plain, @"Ubicaci(?:\u00f3|o)n\s*:\s*([^\n]+)", RegexOptions.IgnoreCase).Groups[1].Value.Trim();
         if (string.IsNullOrWhiteSpace(ubic)) ubic = null;
-
-        string? documento = Regex.Match(plain, @"Tipo de Documento\s*:\s*([^\n]+)", RegexOptions.IgnoreCase).Groups[1].Value.Trim();
-        if (string.IsNullOrWhiteSpace(documento)) documento = null;
-
-        string? contribuyente = Regex.Match(plain, @"Tipo Contribuyente\s*:\s*([^\n]+)", RegexOptions.IgnoreCase).Groups[1].Value.Trim();
-        if (string.IsNullOrWhiteSpace(contribuyente)) contribuyente = null;
+        if (documento == null)
+        {
+            var m = Regex.Match(plain, @"Tipo de Documento\s*:\s*([^\n]+)", RegexOptions.IgnoreCase);
+            if (m.Success)
+            {
+                var d = m.Groups[1].Value.Trim();
+                int dash = d.IndexOf('-');
+                documento = (dash > 0 ? d[..dash] : d).Trim();
+            }
+        }
+        if (contribuyente == null)
+        {
+            var m = Regex.Match(plain, @"Tipo Contribuyente\s*:\s*([^\n]+)", RegexOptions.IgnoreCase);
+            if (m.Success)
+            {
+                var d = m.Groups[1].Value.Trim();
+                int dash = d.IndexOf('-');
+                contribuyente = (dash > 0 ? d[..dash] : d).Trim();
+            }
+        }
 
         return new RucInfo(
             ruc,


### PR DESCRIPTION
## Summary
- unify parsing logic by updating `DocumentPageParser` to use the same HTML parsing approach as `RucPageParser`

## Testing
- `dotnet restore SunatScraper.Core/SunatScraper.Core.csproj`
- `dotnet build SunatScraper.Core/SunatScraper.Core.csproj --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6852a78341dc832c8becc0e17a9f666e