### PR TITLE
Fix /rs endpoint to get full RUC info

### DIFF
--- a/SunatScraper.Api/Program.cs
+++ b/SunatScraper.Api/Program.cs
@@ -15,5 +15,6 @@ app.MapGet("/",()=> "SUNAT RUC API ok");
 app.MapGet("/ruc/{r}",async([FromServices]SunatClient s,string r)=>Results.Json(await s.ByRucAsync(r)));
 app.MapGet("/doc/{t}/{n}",async([FromServices]SunatClient s,string t,string n)=>Results.Json(await s.ByDocumentoAsync(t,n)));
 app.MapGet("/doc/{t}/{n}/lista",async([FromServices]SunatClient s,string t,string n)=>Results.Json(await s.SearchDocumentoAsync(t,n)));
+app.MapGet("/rs/lista",async([FromServices]SunatClient s,[FromQuery]string q)=>Results.Json(await s.SearchRazonAsync(q)));
 app.MapGet("/rs",async([FromServices]SunatClient s,[FromQuery]string q)=>Results.Json(await s.ByRazonAsync(q)));
 app.Run();

--- a/SunatScraper.Core/Services/SunatClient.cs
+++ b/SunatScraper.Core/Services/SunatClient.cs
@@ -48,9 +48,20 @@ public sealed class SunatClient
         var html = await SendRawAsync("consPorTipdoc",("tipdoc",t),("nrodoc",n));
         return RucParser.ParseList(html, true).ToList();
     }
-    public Task<RucInfo> ByRazonAsync(string q){
+    public async Task<IReadOnlyList<SearchResultItem>> SearchRazonAsync(string q)
+    {
         if(!InputGuards.IsValidTexto(q)) throw new ArgumentException("Texto inválido");
-        return SendAsync("consPorRazonSoc",("razSoc",q));
+        var html = await SendRawAsync("consPorRazonSoc",("razSoc",q));
+        return RucParser.ParseList(html).ToList();
+    }
+    public async Task<RucInfo> ByRazonAsync(string q)
+    {
+        if(!InputGuards.IsValidTexto(q)) throw new ArgumentException("Texto inválido");
+        var html = await SendRawAsync("consPorRazonSoc",("razSoc",q));
+        var list = RucParser.ParseList(html).ToList();
+        if(list.Count>0 && !string.IsNullOrWhiteSpace(list[0].Ruc))
+            return await ByRucAsync(list[0].Ruc!);
+        return RucParser.Parse(html);
     }
     private async Task<string> SendRawAsync(string accion, params (string k,string v)[] ex){
         var form=new Dictionary<string,string>{{"accion",accion}};


### PR DESCRIPTION
## Summary
- parse result list when searching by razon social
- when there's at least one result, fetch full record by RUC
- add `/rs/lista` endpoint and docs for search by razon social
- modernize README with more visuals and extended architecture section

## Testing
- `dotnet build SunatScraper.Api/SunatScraper.Api.csproj -nologo`


------
https://chatgpt.com/codex/tasks/task_e_6852abd3528c832cab878b31a1c2254e