### PR TITLE
Add ubicacion data to /rs endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ La API quedará disponible en `http://localhost:5000/`.
 - `GET /doc/{tipo}/{numero}` – Búsqueda por tipo y número de documento.
 - `GET /doc/{tipo}/{numero}/lista` – Devuelve la "Relación de contribuyentes" para el documento indicado.
 - `GET /rs/lista?q={razon social}` – Lista de resultados por razón social.
-- `GET /rs?q={razon social}` – Búsqueda por nombre o razón social.
+- `GET /rs?q={razon social}` – Búsqueda por nombre o razón social. El resultado incluye `ubicacion` cuando está disponible.
 
 ## 💻 Ejemplos de uso
 ### Consulta por RUC

--- a/SunatScraper.Core/Services/SunatClient.cs
+++ b/SunatScraper.Core/Services/SunatClient.cs
@@ -59,9 +59,14 @@ public sealed class SunatClient
         if(!InputGuards.IsValidTexto(q)) throw new ArgumentException("Texto inválido");
         var html = await SendRawAsync("consPorRazonSoc",("razSoc",q));
         var list = RucParser.ParseList(html).ToList();
+        string? ubicacion = list.Count>0 ? list[0].Ubicacion : null;
         if(list.Count>0 && !string.IsNullOrWhiteSpace(list[0].Ruc))
-            return await ByRucAsync(list[0].Ruc!);
-        return RucParser.Parse(html);
+        {
+            var info = await ByRucAsync(list[0].Ruc!);
+            return !string.IsNullOrWhiteSpace(ubicacion) ? info with { Ubicacion = ubicacion } : info;
+        }
+        var parsed = RucParser.Parse(html);
+        return !string.IsNullOrWhiteSpace(ubicacion) ? parsed with { Ubicacion = ubicacion } : parsed;
     }
     private async Task<string> SendRawAsync(string accion, params (string k,string v)[] ex){
         var form=new Dictionary<string,string>{{"accion",accion}};


### PR DESCRIPTION
## Summary
- propagate location info from search list into the `/rs` query
- document that `/rs` now includes `ubicacion` when available

## Testing
- `dotnet build SunatScraper.Api/SunatScraper.Api.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6852b3bcf0c4832c91bad8ef22a51276