### PR TITLE
Refine naming and readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,10 @@ solución de consulta de RUC que expone esta API.
 │   ├── Services
 │   ├── SunatScraper.Core.csproj
 │   └── Validation
-└── SunatScraper.Grpc
-    ├── Services
-    ├── SunatScraper.Grpc.csproj
-    └── sunat.proto
+├── SunatScraper.Grpc
+│   ├── Services
+│   ├── SunatScraper.Grpc.csproj
+│   └── sunat.proto
 ```
 
 ## ⚠️ Advertencia

--- a/SunatScraper.Core/Services/SunatClient.cs
+++ b/SunatScraper.Core/Services/SunatClient.cs
@@ -1,114 +1,183 @@
 namespace SunatScraper.Core.Services;
-using SunatScraper.Core.Models;
-using SunatScraper.Core.Validation;
+
 using Microsoft.Extensions.Caching.Memory;
 using StackExchange.Redis;
+using SunatScraper.Core.Models;
+using SunatScraper.Core.Validation;
+using System.Net;
 using System.Text;
 using System.Text.Json;
-using System.Net;
-using System.Linq;
-public sealed class SunatClient
+
+/// <summary>
+/// Abstraction for consult operations against the SUNAT website.
+/// </summary>
+public interface ISunatClient
 {
-    private readonly HttpClient _http;
-    private readonly SunatSecurity _sec;
-    private readonly IMemoryCache _mem;
-    private readonly IDatabase? _redis;
-    private readonly CookieContainer _cookie;
-    private SunatClient(HttpClient h,IMemoryCache m,IDatabase? r,CookieContainer c){
-        _http=h;_mem=m;_redis=r;_cookie=c;_sec=new SunatSecurity(h);
+    Task<RucInfo> ByRucAsync(string ruc);
+    Task<RucInfo> ByDocumentoAsync(string tipo, string numero);
+    Task<IReadOnlyList<SearchResultItem>> SearchDocumentoAsync(string tipo, string numero);
+    Task<IReadOnlyList<SearchResultItem>> SearchRazonAsync(string query);
+    Task<RucInfo> ByRazonAsync(string query);
+}
+
+/// <summary>
+/// HTTP client implementation for <see cref="ISunatClient"/>.
+/// </summary>
+public sealed class SunatClient : ISunatClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly SunatSecurity _security;
+    private readonly IMemoryCache _memoryCache;
+    private readonly IDatabase? _redisDatabase;
+    private readonly CookieContainer _cookieJar;
+
+    private SunatClient(HttpClient httpClient, IMemoryCache memoryCache, IDatabase? redisDatabase, CookieContainer cookieJar)
+    {
+        _httpClient = httpClient;
+        _memoryCache = memoryCache;
+        _redisDatabase = redisDatabase;
+        _cookieJar = cookieJar;
+        _security = new SunatSecurity(httpClient);
+
         Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
     }
-    public static SunatClient Create(string? redis=null){
-        var jar=new CookieContainer();
-        var handler=new HttpClientHandler{CookieContainer=jar,AutomaticDecompression=DecompressionMethods.All};
-        var http=new HttpClient(handler){BaseAddress=new Uri("https://e-consultaruc.sunat.gob.pe/")};
-        http.DefaultRequestHeaders.UserAgent.ParseAdd(
+    public static ISunatClient Create(string? redisConnection = null)
+    {
+        var cookieJar = new CookieContainer();
+        var handler = new HttpClientHandler
+        {
+            CookieContainer = cookieJar,
+            AutomaticDecompression = DecompressionMethods.All
+        };
+
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://e-consultaruc.sunat.gob.pe/")
+        };
+
+        httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
             "AppleWebKit/537.36 (KHTML, like Gecko) " +
             "Chrome/122.0.0.0 Safari/537.36");
-        http.DefaultRequestHeaders.Accept.ParseAdd("text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
-        http.DefaultRequestHeaders.Add("Upgrade-Insecure-Requests","1");
-        http.DefaultRequestHeaders.AcceptLanguage.ParseAdd("es-PE,es;q=0.9");
-        var mem=new MemoryCache(new MemoryCacheOptions{SizeLimit=2048});
-        IDatabase? db= redis is null ? null : ConnectionMultiplexer.Connect(redis).GetDatabase();
-        return new SunatClient(http,mem,db,jar);
+        httpClient.DefaultRequestHeaders.Accept.ParseAdd("text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
+        httpClient.DefaultRequestHeaders.Add("Upgrade-Insecure-Requests", "1");
+        httpClient.DefaultRequestHeaders.AcceptLanguage.ParseAdd("es-PE,es;q=0.9");
+
+        var memory = new MemoryCache(new MemoryCacheOptions { SizeLimit = 2048 });
+        IDatabase? db = redisConnection is null ? null : ConnectionMultiplexer.Connect(redisConnection).GetDatabase();
+
+        return new SunatClient(httpClient, memory, db, cookieJar);
     }
-    public Task<RucInfo> ByRucAsync(string r)=>SendAsync("consPorRuc",("nroRuc",r));
-    public async Task<RucInfo> ByDocumentoAsync(string t,string n){
-        if(!InputGuards.IsValidDocumento(t,n)) throw new ArgumentException("Doc inválido");
-        var html = await SendRawAsync("consPorTipdoc",("tipdoc",t),("nrodoc",n));
+    public Task<RucInfo> ByRucAsync(string ruc) =>
+        SendAsync("consPorRuc", ("nroRuc", ruc));
+
+    public async Task<RucInfo> ByDocumentoAsync(string tipo, string numero)
+    {
+        if (!InputGuards.IsValidDocumento(tipo, numero))
+            throw new ArgumentException("Doc inválido");
+
+        var html = await SendRawAsync("consPorTipdoc", ("tipdoc", tipo), ("nrodoc", numero));
         var list = RucParser.ParseList(html, true).ToList();
-        if(list.Count>0 && !string.IsNullOrWhiteSpace(list[0].Ruc))
+
+        if (list.Count > 0 && !string.IsNullOrWhiteSpace(list[0].Ruc))
             return await ByRucAsync(list[0].Ruc!);
+
         return RucParser.Parse(html, true);
     }
-    public async Task<IReadOnlyList<SearchResultItem>> SearchDocumentoAsync(string t,string n)
+
+    public async Task<IReadOnlyList<SearchResultItem>> SearchDocumentoAsync(string tipo, string numero)
     {
-        if(!InputGuards.IsValidDocumento(t,n)) throw new ArgumentException("Doc inválido");
-        var html = await SendRawAsync("consPorTipdoc",("tipdoc",t),("nrodoc",n));
+        if (!InputGuards.IsValidDocumento(tipo, numero))
+            throw new ArgumentException("Doc inválido");
+
+        var html = await SendRawAsync("consPorTipdoc", ("tipdoc", tipo), ("nrodoc", numero));
         return RucParser.ParseList(html, true).ToList();
     }
-    public async Task<IReadOnlyList<SearchResultItem>> SearchRazonAsync(string q)
+
+    public async Task<IReadOnlyList<SearchResultItem>> SearchRazonAsync(string query)
     {
-        if(!InputGuards.IsValidTexto(q)) throw new ArgumentException("Texto inválido");
-        var html = await SendRawAsync("consPorRazonSoc",("razSoc",q));
+        if (!InputGuards.IsValidTexto(query))
+            throw new ArgumentException("Texto inválido");
+
+        var html = await SendRawAsync("consPorRazonSoc", ("razSoc", query));
         return RucParser.ParseList(html).ToList();
     }
-    public async Task<RucInfo> ByRazonAsync(string q)
+
+    public async Task<RucInfo> ByRazonAsync(string query)
     {
-        if(!InputGuards.IsValidTexto(q)) throw new ArgumentException("Texto inválido");
-        var html = await SendRawAsync("consPorRazonSoc",("razSoc",q));
+        if (!InputGuards.IsValidTexto(query))
+            throw new ArgumentException("Texto inválido");
+
+        var html = await SendRawAsync("consPorRazonSoc", ("razSoc", query));
         var list = RucParser.ParseList(html).ToList();
-        string? ubicacion = list.Count>0 ? list[0].Ubicacion : null;
-        if(list.Count>0 && !string.IsNullOrWhiteSpace(list[0].Ruc))
+        string? ubicacion = list.Count > 0 ? list[0].Ubicacion : null;
+
+        if (list.Count > 0 && !string.IsNullOrWhiteSpace(list[0].Ruc))
         {
             var info = await ByRucAsync(list[0].Ruc!);
             return !string.IsNullOrWhiteSpace(ubicacion) ? info with { Ubicacion = ubicacion } : info;
         }
+
         var parsed = RucParser.Parse(html);
         return !string.IsNullOrWhiteSpace(ubicacion) ? parsed with { Ubicacion = ubicacion } : parsed;
     }
-    private async Task<string> SendRawAsync(string accion, params (string k,string v)[] ex){
-        var form=new Dictionary<string,string>{{"accion",accion}};
-        foreach(var (k,v) in ex)form[k]=v;
-        string key=JsonSerializer.Serialize(form);
-        if(_mem.TryGetValue(key,out string? cachedHtml) && cachedHtml is not null)
+    private async Task<string> SendRawAsync(string accion, params (string k, string v)[] extras)
+    {
+        var form = new Dictionary<string, string> { { "accion", accion } };
+        foreach (var (k, v) in extras)
+            form[k] = v;
+
+        var key = JsonSerializer.Serialize(form);
+
+        if (_memoryCache.TryGetValue(key, out string? cachedHtml) && cachedHtml is not null)
             return cachedHtml;
-        if(_redis!=null)
+
+        if (_redisDatabase != null)
         {
-            var j=_redis.StringGet(key);
-            if(j.HasValue) return j.ToString();
+            var j = _redisDatabase.StringGet(key);
+            if (j.HasValue) return j.ToString();
         }
-        var initRes=await _http.GetAsync("cl-ti-itmrconsruc/FrameCriterioBusquedaWeb.jsp");
-        if(initRes.IsSuccessStatusCode){
-            var body=await initRes.Content.ReadAsStringAsync();
+
+        var initRes = await _httpClient.GetAsync("cl-ti-itmrconsruc/FrameCriterioBusquedaWeb.jsp");
+        if (initRes.IsSuccessStatusCode)
+        {
+            var body = await initRes.Content.ReadAsStringAsync();
             const string pat = @"document\.cookie\s*=\s*""([^""]+)""";
-            foreach(System.Text.RegularExpressions.Match m in System.Text.RegularExpressions.Regex.Matches(body,pat)){
-                var cookie=m.Groups[1].Value.Split(';',2)[0];
-                var p=cookie.IndexOf('=');
-                if(p>0){
-                    _cookie.Add(new Uri(_http.BaseAddress!,"/"),new Cookie(cookie[..p],cookie[(p+1)..]));
+            foreach (System.Text.RegularExpressions.Match m in System.Text.RegularExpressions.Regex.Matches(body, pat))
+            {
+                var cookie = m.Groups[1].Value.Split(';', 2)[0];
+                var p = cookie.IndexOf('=');
+                if (p > 0)
+                {
+                    _cookieJar.Add(new Uri(_httpClient.BaseAddress!, "/"), new Cookie(cookie[..p], cookie[(p + 1)..]));
                 }
             }
         }
-        form["token"]=_sec.GenerateToken();
-        form["codigo"]=await _sec.SolveCaptchaAsync();
-        form["numRnd"]=_sec.LastRandom.ToString();
-        form["contexto"]="ti-it";form["modo"]="1";
-        using var req=new HttpRequestMessage(HttpMethod.Post,"cl-ti-itmrconsruc/jcrS00Alias"){
-            Content=new FormUrlEncodedContent(form)
+
+        form["token"] = _security.GenerateToken();
+        form["codigo"] = await _security.SolveCaptchaAsync();
+        form["numRnd"] = _security.LastRandom.ToString();
+        form["contexto"] = "ti-it";
+        form["modo"] = "1";
+
+        using var req = new HttpRequestMessage(HttpMethod.Post, "cl-ti-itmrconsruc/jcrS00Alias")
+        {
+            Content = new FormUrlEncodedContent(form)
         };
-        req.Headers.Referrer=new Uri(_http.BaseAddress!,"cl-ti-itmrconsruc/FrameCriterioBusquedaWeb.jsp");
-        using var res=await _http.SendAsync(req);
+        req.Headers.Referrer = new Uri(_httpClient.BaseAddress!, "cl-ti-itmrconsruc/FrameCriterioBusquedaWeb.jsp");
+
+        using var res = await _httpClient.SendAsync(req);
         res.EnsureSuccessStatusCode();
-        var html=Encoding.GetEncoding("ISO-8859-1").GetString(await res.Content.ReadAsByteArrayAsync());
-        _mem.Set(key,html,new MemoryCacheEntryOptions{Size=1,SlidingExpiration=TimeSpan.FromHours(6)});
-        _redis?.StringSet(key,html,TimeSpan.FromHours(12));
+
+        var html = Encoding.GetEncoding("ISO-8859-1").GetString(await res.Content.ReadAsByteArrayAsync());
+        _memoryCache.Set(key, html, new MemoryCacheEntryOptions { Size = 1, SlidingExpiration = TimeSpan.FromHours(6) });
+        _redisDatabase?.StringSet(key, html, TimeSpan.FromHours(12));
         return html;
     }
 
-    private async Task<RucInfo> SendAsync(string accion, params (string k,string v)[] ex){
-        var html = await SendRawAsync(accion,ex);
+    private async Task<RucInfo> SendAsync(string accion, params (string k, string v)[] extras)
+    {
+        var html = await SendRawAsync(accion, extras);
         var info = RucParser.Parse(html, accion == "consPorTipdoc");
         return info;
     }

--- a/SunatScraper.Core/Validation/InputGuards.cs
+++ b/SunatScraper.Core/Validation/InputGuards.cs
@@ -1,18 +1,38 @@
 namespace SunatScraper.Core.Validation;
-using System.Linq;
+
+/// <summary>
+/// Helper methods to validate incoming parameters.
+/// </summary>
 public static class InputGuards
 {
-    public static bool IsValidDocumento(string tipdoc,string num)=>tipdoc switch
+    public static bool IsValidDocumento(string tipdoc, string num) => tipdoc switch
     {
-        "1"=>num.Length==8 && num.All(char.IsDigit),
-        "4"=>IsAlnum(num,9,12),
-        "7"=>IsAlnum(num,6,12),
-        "A"=>IsAlnum(num,6,12),
-        _=>false
+        "1" => num.Length == 8 && num.All(char.IsDigit),
+        "4" => IsAlnum(num, 9, 12),
+        "7" => IsAlnum(num, 6, 12),
+        "A" => IsAlnum(num, 6, 12),
+        _ => false
     };
-    static bool IsAlnum(string s,int mi,int ma)=>s.Length>=mi&&s.Length<=ma&&s.All(char.IsLetterOrDigit);
-    static readonly int[] W={5,4,3,2,7,6,5,4,3,2};
-    public static bool IsValidRuc(string r)=>r.Length==11&&r.All(char.IsDigit)&&Chk(r)==r[^1]-'0';
-    static int Chk(string r){int s=0;for(int i=0;i<10;i++)s+=(r[i]-'0')*W[i];int m=11-(s%11);return m==10?0:m==11?1:m;}
-    public static bool IsValidTexto(string t)=>t.Length is>=4 and<=100&&t.All(c=>char.IsLetterOrDigit(c)||c is ' ' or '.' or ',' or '-');
+
+    private static bool IsAlnum(string s, int min, int max) =>
+        s.Length >= min && s.Length <= max && s.All(char.IsLetterOrDigit);
+
+    private static readonly int[] W = { 5, 4, 3, 2, 7, 6, 5, 4, 3, 2 };
+
+    public static bool IsValidRuc(string r) =>
+        r.Length == 11 && r.All(char.IsDigit) && Chk(r) == r[^1] - '0';
+
+    private static int Chk(string r)
+    {
+        int s = 0;
+        for (int i = 0; i < 10; i++)
+            s += (r[i] - '0') * W[i];
+
+        int m = 11 - (s % 11);
+        return m == 10 ? 0 : m == 11 ? 1 : m;
+    }
+
+    public static bool IsValidTexto(string t) =>
+        t.Length is >= 4 and <= 100 &&
+        t.All(c => char.IsLetterOrDigit(c) || c is ' ' or '.' or ',' or '-');
 }

--- a/SunatScraper.Grpc/Services/RucGrpcService.cs
+++ b/SunatScraper.Grpc/Services/RucGrpcService.cs
@@ -2,15 +2,23 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using SunatScraper.Core.Services;
 using SunatScraper.Grpc;
+
 public class RucGrpcService : Sunat.SunatBase
 {
-    private readonly SunatClient _svc;
-    public RucGrpcService(SunatClient s)=>_svc=s;
-    public override async Task<RucReply> GetByRuc(RucRequest r,ServerCallContext _)=>
-        Map(await _svc.ByRucAsync(r.Ruc));
-    static RucReply Map(SunatScraper.Core.Models.RucInfo i)=>new(){
-        Ruc=i.Ruc??"",RazonSocial=i.RazonSocial??"",Estado=i.Estado??"",
-        Condicion=i.Condicion??"",Direccion=i.Direccion??""
+    private readonly ISunatClient _client;
+
+    public RucGrpcService(ISunatClient client) => _client = client;
+
+    public override async Task<RucReply> GetByRuc(RucRequest request, ServerCallContext _) =>
+        Map(await _client.ByRucAsync(request.Ruc));
+
+    private static RucReply Map(SunatScraper.Core.Models.RucInfo info) => new()
+    {
+        Ruc = info.Ruc ?? string.Empty,
+        RazonSocial = info.RazonSocial ?? string.Empty,
+        Estado = info.Estado ?? string.Empty,
+        Condicion = info.Condicion ?? string.Empty,
+        Direccion = info.Direccion ?? string.Empty
     };
 }
 

--- a/SunatScraper.sln
+++ b/SunatScraper.sln
@@ -1,0 +1,62 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SunatScraper.Api", "SunatScraper.Api\SunatScraper.Api.csproj", "{5A6F4E3F-C422-4A3D-A618-15688EE837DB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SunatScraper.Core", "SunatScraper.Core\SunatScraper.Core.csproj", "{F05A6242-D14B-4423-8218-B6375D3E888B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SunatScraper.Grpc", "SunatScraper.Grpc\SunatScraper.Grpc.csproj", "{3210FDCF-8A00-4279-AA6F-0806A13AAFBC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5A6F4E3F-C422-4A3D-A618-15688EE837DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A6F4E3F-C422-4A3D-A618-15688EE837DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A6F4E3F-C422-4A3D-A618-15688EE837DB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5A6F4E3F-C422-4A3D-A618-15688EE837DB}.Debug|x64.Build.0 = Debug|Any CPU
+		{5A6F4E3F-C422-4A3D-A618-15688EE837DB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5A6F4E3F-C422-4A3D-A618-15688EE837DB}.Debug|x86.Build.0 = Debug|Any CPU
+		{5A6F4E3F-C422-4A3D-A618-15688EE837DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A6F4E3F-C422-4A3D-A618-15688EE837DB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A6F4E3F-C422-4A3D-A618-15688EE837DB}.Release|x64.ActiveCfg = Release|Any CPU
+		{5A6F4E3F-C422-4A3D-A618-15688EE837DB}.Release|x64.Build.0 = Release|Any CPU
+		{5A6F4E3F-C422-4A3D-A618-15688EE837DB}.Release|x86.ActiveCfg = Release|Any CPU
+		{5A6F4E3F-C422-4A3D-A618-15688EE837DB}.Release|x86.Build.0 = Release|Any CPU
+		{F05A6242-D14B-4423-8218-B6375D3E888B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F05A6242-D14B-4423-8218-B6375D3E888B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F05A6242-D14B-4423-8218-B6375D3E888B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F05A6242-D14B-4423-8218-B6375D3E888B}.Debug|x64.Build.0 = Debug|Any CPU
+		{F05A6242-D14B-4423-8218-B6375D3E888B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F05A6242-D14B-4423-8218-B6375D3E888B}.Debug|x86.Build.0 = Debug|Any CPU
+		{F05A6242-D14B-4423-8218-B6375D3E888B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F05A6242-D14B-4423-8218-B6375D3E888B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F05A6242-D14B-4423-8218-B6375D3E888B}.Release|x64.ActiveCfg = Release|Any CPU
+		{F05A6242-D14B-4423-8218-B6375D3E888B}.Release|x64.Build.0 = Release|Any CPU
+		{F05A6242-D14B-4423-8218-B6375D3E888B}.Release|x86.ActiveCfg = Release|Any CPU
+		{F05A6242-D14B-4423-8218-B6375D3E888B}.Release|x86.Build.0 = Release|Any CPU
+		{3210FDCF-8A00-4279-AA6F-0806A13AAFBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3210FDCF-8A00-4279-AA6F-0806A13AAFBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3210FDCF-8A00-4279-AA6F-0806A13AAFBC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3210FDCF-8A00-4279-AA6F-0806A13AAFBC}.Debug|x64.Build.0 = Debug|Any CPU
+		{3210FDCF-8A00-4279-AA6F-0806A13AAFBC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3210FDCF-8A00-4279-AA6F-0806A13AAFBC}.Debug|x86.Build.0 = Debug|Any CPU
+		{3210FDCF-8A00-4279-AA6F-0806A13AAFBC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3210FDCF-8A00-4279-AA6F-0806A13AAFBC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3210FDCF-8A00-4279-AA6F-0806A13AAFBC}.Release|x64.ActiveCfg = Release|Any CPU
+		{3210FDCF-8A00-4279-AA6F-0806A13AAFBC}.Release|x64.Build.0 = Release|Any CPU
+		{3210FDCF-8A00-4279-AA6F-0806A13AAFBC}.Release|x86.ActiveCfg = Release|Any CPU
+		{3210FDCF-8A00-4279-AA6F-0806A13AAFBC}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- use clearer variable names in `SunatClient` and `SunatSecurity`
- rename parameters in API endpoints for clarity

## Testing
- `dotnet build SunatScraper.Api/SunatScraper.Api.csproj -p:ConsoleLoggerParameters=DisableConsoleColor -nologo`


------
https://chatgpt.com/codex/tasks/task_e_6852c16b4470832ca5e8710a76661c49