### PR TITLE
Improve README aesthetics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,64 +25,106 @@ dotnet run --project SunatScraper.Api
 La API quedará disponible en `http://localhost:5000/`.
 
 ## 📁 Endpoints principales
-- `GET /` – Comprobación de funcionamiento.
-- `GET /ruc/{ruc}` – Consulta por número de RUC.
-- `GET /doc/{tipo}/{numero}` – Búsqueda por tipo y número de documento.
-- `GET /doc/{tipo}/{numero}/lista` – Devuelve la "Relación de contribuyentes" para el documento indicado.
-- `GET /rs/lista?q={razon social}` – Lista de resultados por razón social.
-- `GET /rs?q={razon social}` – Búsqueda por nombre o razón social. El resultado incluye `ubicacion` cuando está disponible.
+
+| Método | Endpoint | Descripción |
+|--------|----------|-------------|
+| `GET`  | `/` | Comprobación de funcionamiento |
+| `GET`  | `/ruc/{ruc}` | Consulta por número de RUC |
+| `GET`  | `/doc/{tipo}/{numero}` | Búsqueda por tipo y número de documento |
+| `GET`  | `/doc/{tipo}/{numero}/lista` | Devuelve la "Relación de contribuyentes" para el documento indicado |
+| `GET`  | `/rs/lista?q={razon social}` | Lista de resultados por razón social |
+| `GET`  | `/rs?q={razon social}` | Búsqueda por nombre o razón social (incluye `ubicacion` cuando está disponible) |
 
 ## 💻 Ejemplos de uso
-### Consulta por RUC
+
+<details>
+<summary>Consulta por RUC</summary>
+
 ```bash
 curl http://localhost:5000/ruc/20100113774
 ```
+</details>
 
-### Búsqueda por documento (DNI)
+<details>
+<summary>Búsqueda por documento (DNI)</summary>
+
 ```bash
 curl http://localhost:5000/doc/1/73870570
 ```
-### Búsqueda por documento (Carnet de Extranjería)
+</details>
+
+<details>
+<summary>Búsqueda por documento (Carnet de Extranjería)</summary>
+
 ```bash
 curl http://localhost:5000/doc/4/X12345678
 ```
-### Búsqueda por documento (Pasaporte)
+</details>
+
+<details>
+<summary>Búsqueda por documento (Pasaporte)</summary>
+
 ```bash
 curl http://localhost:5000/doc/7/AB123456
 ```
-### Búsqueda por documento (Cédula Diplomática)
+</details>
+
+<details>
+<summary>Búsqueda por documento (Cédula Diplomática)</summary>
+
 ```bash
 curl http://localhost:5000/doc/A/CD12345
 ```
-### Obtener lista de resultados para un documento
+</details>
+
+<details>
+<summary>Obtener lista de resultados para un documento</summary>
+
 ```bash
 curl http://localhost:5000/doc/1/73870570/lista
 ```
+</details>
 
-### Obtener lista de resultados por razón social
+<details>
+<summary>Obtener lista de resultados por razón social</summary>
+
 ```bash
 curl "http://localhost:5000/rs/lista?q=ACME"
 ```
+</details>
 
-### Búsqueda por razón social
+<details>
+<summary>Búsqueda por razón social</summary>
+
 ```bash
 curl "http://localhost:5000/rs?q=ACME"
 ```
-### Búsqueda por razón social con espacios
+</details>
+
+<details>
+<summary>Búsqueda por razón social con espacios</summary>
+
 ```bash
 curl "http://localhost:5000/rs?q=LOS%20POLLOS%20HERMANOS"
 ```
+</details>
 
-### Ejemplo con Redis activado
+<details>
+<summary>Ejemplo con Redis activado</summary>
+
 ```bash
 Redis=localhost:6379 dotnet run --project SunatScraper.Api
 curl http://localhost:5000/ruc/20100113774
 ```
+</details>
 
-### Consulta vía gRPC
+<details>
+<summary>Consulta vía gRPC</summary>
+
 ```bash
 grpcurl -d '{"ruc":"20100113774"}' -plaintext localhost:5000 Sunat/GetByRuc
 ```
+</details>
 
 ## 📄 Arquitectura
 El proyecto se compone de tres módulos bien definidos:
@@ -124,24 +166,19 @@ graph TD;
 - ⚡ **Caching** en memoria o Redis para optimizar las consultas repetitivas.
 
 ### ¿Por qué C# .NET?
-C# es un lenguaje moderno y fuertemente tipado que se ejecuta sobre el runtime
-de .NET. Su compilación JIT y las optimizaciones del CLR permiten obtener un
-alto rendimiento en aplicaciones de red sin sacrificar la legibilidad del
-código. Además, .NET es totalmente multiplataforma: la API puede desplegarse en
-Windows, Linux o contenedores Docker sin modificaciones.
 
-La biblioteca estándar ofrece utilidades listas para usar en escenarios de
-procesamiento de HTTP, serialización de JSON y manipulación de HTML,
-pilares fundamentales de este proyecto. Las facilidades de programación
-asíncrona con `async`/`await` simplifican la implementación de clientes web
-concurrentes y de servidores de alto rendimiento.
+> C# es un lenguaje moderno y fuertemente tipado que se ejecuta sobre el runtime de .NET. Su compilación JIT y las optimizaciones del CLR permiten obtener un alto rendimiento en aplicaciones de red sin sacrificar la legibilidad del código. Además, .NET es completamente multiplataforma: la API puede desplegarse en Windows, Linux o contenedores Docker sin modificaciones.
+>
+> La biblioteca estándar ofrece utilidades listas para usar en escenarios de procesamiento de HTTP, serialización de JSON y manipulación de HTML, pilares fundamentales de este proyecto. Las facilidades de programación asíncrona con `async`/`await` simplifican la implementación de clientes web concurrentes y de servidores de alto rendimiento.
+>
+> El amplio ecosistema de .NET incluye frameworks integrados para exponer endpoints REST y servicios gRPC, permitiendo reutilizar la misma lógica de negocio en distintas formas de comunicación. Gracias a la inyección de dependencias nativa es sencillo mantener las capas desacopladas y preparar el código para pruebas automatizadas, facilitando así la mantenibilidad a largo plazo.
 
-El amplio ecosistema de .NET incluye frameworks integrados para exponer
-endpoints REST y servicios gRPC, permitiendo reutilizar la misma lógica de
-negocio en distintas formas de comunicación. Gracias a la inyección de
-dependencias nativa es sencillo mantener las capas desacopladas y preparar el
-código para pruebas automatizadas, facilitando así la mantenibilidad a largo
-plazo.
+- 🏎️ **Alto rendimiento** gracias a la compilación JIT del CLR.
+- 🖥️ **Multiplataforma**: ejecuta la API en Windows, Linux o contenedores Docker.
+- 📚 **Biblioteca estándar completa** para HTTP, JSON y HTML.
+- 😌 **Asincronía sencilla** con `async`/`await` para clientes y servidores eficientes.
+- 🔌 **Frameworks integrados** para REST y gRPC con la misma lógica de negocio.
+- 🔧 **Inyección de dependencias** nativa que facilita las pruebas y el mantenimiento.
 
 ### Despliegue
 La aplicación puede publicarse como un ejecutable autocontenible o ejecutarse

--- a/SunatScraper.Api/Program.cs
+++ b/SunatScraper.Api/Program.cs
@@ -1,3 +1,5 @@
+// Punto de entrada de la aplicación API.
+// Configura los servicios y define los endpoints HTTP.
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http.Json;
 using System.Text.Json.Serialization;

--- a/SunatScraper.Domain/ISunatClient.cs
+++ b/SunatScraper.Domain/ISunatClient.cs
@@ -1,3 +1,4 @@
+// Contrato de operaciones para consultar información en la SUNAT.
 namespace SunatScraper.Domain;
 using SunatScraper.Domain.Models;
 

--- a/SunatScraper.Domain/Models/RucInfo.cs
+++ b/SunatScraper.Domain/Models/RucInfo.cs
@@ -1,3 +1,4 @@
+// Modelo que representa la información detallada de un RUC consultado.
 namespace SunatScraper.Domain.Models;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/SunatScraper.Domain/Models/SearchResultItem.cs
+++ b/SunatScraper.Domain/Models/SearchResultItem.cs
@@ -1,3 +1,4 @@
+// Representa un elemento en los resultados de búsqueda de la SUNAT.
 namespace SunatScraper.Domain.Models;
 using System.Text.Json;
 public sealed record SearchResultItem(

--- a/SunatScraper.Domain/Validation/InputGuards.cs
+++ b/SunatScraper.Domain/Validation/InputGuards.cs
@@ -1,3 +1,4 @@
+// Métodos auxiliares para validar parámetros de entrada.
 namespace SunatScraper.Domain.Validation;
 
 /// <summary>

--- a/SunatScraper.Grpc/Services/RucGrpcService.cs
+++ b/SunatScraper.Grpc/Services/RucGrpcService.cs
@@ -1,3 +1,4 @@
+// Servicio gRPC que expone las consultas de RUC.
 using System.Threading.Tasks;
 using Grpc.Core;
 using SunatScraper.Domain;

--- a/SunatScraper.Infrastructure/Services/DocumentPageParser.cs
+++ b/SunatScraper.Infrastructure/Services/DocumentPageParser.cs
@@ -1,3 +1,4 @@
+// Analiza la página HTML devuelta por consultas de documento.
 namespace SunatScraper.Infrastructure.Services;
 using HtmlAgilityPack;
 using SunatScraper.Domain.Models;

--- a/SunatScraper.Infrastructure/Services/RucPageParser.cs
+++ b/SunatScraper.Infrastructure/Services/RucPageParser.cs
@@ -1,3 +1,4 @@
+// Analiza el HTML obtenido en las búsquedas por RUC.
 namespace SunatScraper.Infrastructure.Services;
 using HtmlAgilityPack;
 using SunatScraper.Domain.Models;

--- a/SunatScraper.Infrastructure/Services/RucParser.cs
+++ b/SunatScraper.Infrastructure/Services/RucParser.cs
@@ -1,3 +1,4 @@
+// Facilita la elección del parser adecuado para cada tipo de consulta.
 namespace SunatScraper.Infrastructure.Services;
 using SunatScraper.Domain.Models;
 using System.Collections.Generic;

--- a/SunatScraper.Infrastructure/Services/SunatClient.cs
+++ b/SunatScraper.Infrastructure/Services/SunatClient.cs
@@ -1,3 +1,4 @@
+// Cliente HTTP encargado de interactuar con el portal de SUNAT.
 namespace SunatScraper.Infrastructure.Services;
 
 using Microsoft.Extensions.Caching.Memory;
@@ -110,6 +111,7 @@ public sealed class SunatClient : ISunatClient
         var parsed = RucParser.Parse(html);
         return !string.IsNullOrWhiteSpace(ubicacion) ? parsed with { Ubicacion = ubicacion } : parsed;
     }
+    // Envía la solicitud al portal de SUNAT y devuelve el HTML resultante.
     private async Task<string> SendRawAsync(string accion, params (string k, string v)[] extras)
     {
         var form = new Dictionary<string, string> { { "accion", accion } };
@@ -164,6 +166,7 @@ public sealed class SunatClient : ISunatClient
         return html;
     }
 
+    // Método auxiliar que procesa el HTML obtenido y lo convierte en un modelo de dominio.
     private async Task<RucInfo> SendAsync(string accion, params (string k, string v)[] extras)
     {
         var html = await SendRawAsync(accion, extras);

--- a/SunatScraper.Infrastructure/Services/SunatSecurity.cs
+++ b/SunatScraper.Infrastructure/Services/SunatSecurity.cs
@@ -1,4 +1,5 @@
 #define USE_TESSERACT
+// Encapsula la lógica de seguridad y resolución de captcha utilizada por SUNAT.
 namespace SunatScraper.Infrastructure.Services;
 
 using System.Net;
@@ -35,6 +36,7 @@ public class SunatSecurity
         return sb.ToString(0, length);
     }
 
+    // Obtiene y resuelve el captcha; intenta Tesseract antes de recurrir a la entrada manual.
     public async Task<string> SolveCaptchaAsync()
     {
         int rnd = Random.Shared.Next(1, 9999);


### PR DESCRIPTION
## Summary
- restyle main endpoints list as a table
- convert usage examples into collapsible blocks
- restore detailed .NET section with blockquote explanation
- add concise bullet list of .NET advantages
- add Spanish comments to all source files

## Testing
- `dotnet build --nologo`


------
https://chatgpt.com/codex/tasks/task_e_6852d0f87d3c832c9cbcfb3660c05a21