### PR TITLE
Enhance error handling with structured JSON

### DIFF
--- a/SunatScraper.Api/ApiHelpers.cs
+++ b/SunatScraper.Api/ApiHelpers.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using SunatScraper.Domain.Models;
+
+internal static class ApiHelpers
+{
+    internal record ApiError(string Mensaje);
+
+    internal static IResult ToResult(RucInfo info) =>
+        string.IsNullOrWhiteSpace(info.Ruc)
+            ? Results.Json(new ApiError("Registro no encontrado"),
+                statusCode: StatusCodes.Status404NotFound)
+            : Results.Json(info);
+
+    internal static IResult ToResult<T>(IReadOnlyList<T> list) =>
+        list.Count == 0
+            ? Results.Json(new ApiError("Registro no encontrado"),
+                statusCode: StatusCodes.Status404NotFound)
+            : Results.Json(list);
+
+    internal static async Task<IResult> Execute(Func<Task<IResult>> action)
+    {
+        try
+        {
+            return await action();
+        }
+        catch (ArgumentException ex)
+        {
+            return Results.Json(new ApiError(ex.Message),
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+        catch (HttpRequestException)
+        {
+            return Results.Json(new ApiError("No se obtuvo respuesta del portal de SUNAT"),
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+    }
+}

--- a/SunatScraper.Api/Program.cs
+++ b/SunatScraper.Api/Program.cs
@@ -22,29 +22,36 @@ var app = builder.Build();
 app.MapGet("/", () => "SUNAT RUC API ok");
 
 // Consulta información detallada mediante número de RUC.
-app.MapGet("/ruc/{ruc}", async ([FromServices] ISunatClient client, string ruc) =>
-    Results.Json(await client.GetByRucAsync(ruc)));
+app.MapGet("/ruc/{ruc}",
+    ([FromServices] ISunatClient client, string ruc) =>
+        ApiHelpers.Execute(async () => ApiHelpers.ToResult(await client.GetByRucAsync(ruc))));
 
 // Consulta múltiples RUCs en paralelo.
-app.MapGet("/rucs", async ([FromServices] ISunatClient client,
+app.MapGet("/rucs",
+    ([FromServices] ISunatClient client,
         [FromQuery(Name = "r")] string[] rucs) =>
-    Results.Json(await client.GetByRucsAsync(rucs)));
+        ApiHelpers.Execute(async () => Results.Json(await client.GetByRucsAsync(rucs))));
 
 // Búsqueda por tipo y número de documento de identidad.
-app.MapGet("/doc/{tipo}/{numero}", async ([FromServices] ISunatClient client, string tipo, string numero) =>
-    Results.Json(await client.GetByDocumentAsync(tipo, numero)));
+app.MapGet("/doc/{tipo}/{numero}",
+    ([FromServices] ISunatClient client, string tipo, string numero) =>
+        ApiHelpers.Execute(async () => ApiHelpers.ToResult(await client.GetByDocumentAsync(tipo, numero))));
 
 // Devuelve la lista completa de coincidencias para un documento específico.
-app.MapGet("/doc/{tipo}/{numero}/lista", async ([FromServices] ISunatClient client, string tipo, string numero) =>
-    Results.Json(await client.SearchByDocumentAsync(tipo, numero)));
+app.MapGet("/doc/{tipo}/{numero}/lista",
+    ([FromServices] ISunatClient client, string tipo, string numero) =>
+        ApiHelpers.Execute(async () => ApiHelpers.ToResult(await client.SearchByDocumentAsync(tipo, numero))));
 
 // Obtiene las coincidencias de razón social sin datos de ubicación.
-app.MapGet("/rs/lista", async ([FromServices] ISunatClient client,
+app.MapGet("/rs/lista",
+    ([FromServices] ISunatClient client,
         [FromQuery(Name = "q")] string razonSocial) =>
-    Results.Json(await client.SearchByNameAsync(razonSocial)));
+        ApiHelpers.Execute(async () => ApiHelpers.ToResult(await client.SearchByNameAsync(razonSocial))));
 
 // Consulta por razón social retornando ubicación cuando está disponible.
-app.MapGet("/rs", async ([FromServices] ISunatClient client,
+app.MapGet("/rs",
+    ([FromServices] ISunatClient client,
         [FromQuery(Name = "q")] string razonSocial) =>
-    Results.Json(await client.GetByNameAsync(razonSocial)));
+        ApiHelpers.Execute(async () => ApiHelpers.ToResult(await client.GetByNameAsync(razonSocial))));
+
 app.Run();


### PR DESCRIPTION
## Summary
- add helper class `ApiHelpers` to centralize JSON error responses
- update API endpoints to return professional error objects when records are missing or when requests fail

## Testing
- `dotnet format SunatScraper.sln --no-restore`
- `dotnet test --no-restore`
- `dotnet run --project SunatScraper.Api` (launched and served requests)


------
https://chatgpt.com/codex/tasks/task_e_6856374b60d0832cb6816d31d238c877