### PR TITLE
Include Ubicacion in document results

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,18 +169,18 @@ graph TD;
 > Todas las operaciones son `async` y algunas consultas se ejecutan en paralelo
 > para aprovechar al máximo los recursos de la aplicación.
 
-```markmap
-# Principios
-## Capas
-### API / gRPC
-### Dominio
-### Infraestructura
-## Patrones
-### DI
-### Repository
-### Adapter
-### Factory
-### Caching
+```mermaid
+graph TD;
+    A[Principios] --> B[Capas];
+    B --> B1[API / gRPC];
+    B --> B2[Dominio];
+    B --> B3[Infraestructura];
+    A --> C[Patrones];
+    C --> C1[DI];
+    C --> C2[Repository];
+    C --> C3[Adapter];
+    C --> C4[Factory];
+    C --> C5[Caching];
 ```
 
 #### Flujo de datos

--- a/SunatScraper.Api/Program.cs
+++ b/SunatScraper.Api/Program.cs
@@ -1,16 +1,17 @@
 // Punto de entrada principal de la API.
 // Aquí se configuran los servicios y se definen los endpoints HTTP.
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http.Json;
-using System.Text.Json.Serialization;
-using SunatScraper.Infrastructure.Services;
-using SunatScraper.Domain;
+using Microsoft.AspNetCore.Mvc;
 using Serilog;
+using SunatScraper.Domain;
+using SunatScraper.Infrastructure.Services;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Host.UseSerilog((ctx, lc) => lc.WriteTo.Console());
 
+// Configuración de servicios
 builder.Services.AddSingleton<ISunatClient>(_ =>
     SunatClient.Create(builder.Configuration["Redis"]));
 
@@ -19,39 +20,43 @@ builder.Services.ConfigureHttpJsonOptions(o =>
 
 var app = builder.Build();
 
+// Endpoints HTTP
 app.MapGet("/", () => "SUNAT RUC API ok");
 
 // Consulta información detallada mediante número de RUC.
-app.MapGet("/ruc/{ruc}",
+app.MapGet(
+    "/ruc/{ruc}",
     ([FromServices] ISunatClient client, string ruc) =>
         ApiHelpers.Execute(async () => ApiHelpers.ToResult(await client.GetByRucAsync(ruc))));
 
 // Consulta múltiples RUCs en paralelo.
-app.MapGet("/rucs",
-    ([FromServices] ISunatClient client,
-        [FromQuery(Name = "r")] string[] rucs) =>
+app.MapGet(
+    "/rucs",
+    ([FromServices] ISunatClient client, [FromQuery(Name = "r")] string[] rucs) =>
         ApiHelpers.Execute(async () => Results.Json(await client.GetByRucsAsync(rucs))));
 
 // Búsqueda por tipo y número de documento de identidad.
-app.MapGet("/doc/{tipo}/{numero}",
+app.MapGet(
+    "/doc/{tipo}/{numero}",
     ([FromServices] ISunatClient client, string tipo, string numero) =>
         ApiHelpers.Execute(async () => ApiHelpers.ToResult(await client.GetByDocumentAsync(tipo, numero))));
 
 // Devuelve la lista completa de coincidencias para un documento específico.
-app.MapGet("/doc/{tipo}/{numero}/lista",
+app.MapGet(
+    "/doc/{tipo}/{numero}/lista",
     ([FromServices] ISunatClient client, string tipo, string numero) =>
         ApiHelpers.Execute(async () => ApiHelpers.ToResult(await client.SearchByDocumentAsync(tipo, numero))));
 
 // Obtiene las coincidencias de razón social sin datos de ubicación.
-app.MapGet("/rs/lista",
-    ([FromServices] ISunatClient client,
-        [FromQuery(Name = "q")] string razonSocial) =>
+app.MapGet(
+    "/rs/lista",
+    ([FromServices] ISunatClient client, [FromQuery(Name = "q")] string razonSocial) =>
         ApiHelpers.Execute(async () => ApiHelpers.ToResult(await client.SearchByNameAsync(razonSocial))));
 
 // Consulta por razón social retornando ubicación cuando está disponible.
-app.MapGet("/rs",
-    ([FromServices] ISunatClient client,
-        [FromQuery(Name = "q")] string razonSocial) =>
+app.MapGet(
+    "/rs",
+    ([FromServices] ISunatClient client, [FromQuery(Name = "q")] string razonSocial) =>
         ApiHelpers.Execute(async () => ApiHelpers.ToResult(await client.GetByNameAsync(razonSocial))));
 
 app.Run();

--- a/SunatScraper.Infrastructure/Services/SunatClient.cs
+++ b/SunatScraper.Infrastructure/Services/SunatClient.cs
@@ -94,11 +94,20 @@ public sealed class SunatClient : ISunatClient, IDisposable
 
         var html = await SendRawAsync("consPorTipdoc", ("tipdoc", tipo), ("nrodoc", numero));
         var results = RucParser.ParseList(html, true).ToList();
+        string? ubicacion = results.Count > 0 ? results[0].Ubicacion : null;
 
         if (results.Count > 0 && !string.IsNullOrWhiteSpace(results[0].Ruc))
-            return await GetByRucAsync(results[0].Ruc!);
+        {
+            var details = await GetByRucAsync(results[0].Ruc!);
+            return !string.IsNullOrWhiteSpace(ubicacion)
+                ? details with { Ubicacion = ubicacion }
+                : details;
+        }
 
-        return RucParser.Parse(html, true);
+        var parsed = RucParser.Parse(html, true);
+        return !string.IsNullOrWhiteSpace(ubicacion)
+            ? parsed with { Ubicacion = ubicacion }
+            : parsed;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- preserve `Ubicacion` when resolving document-based searches
- replace unsupported markmap diagram with mermaid

## Testing
- `dotnet build SunatScraper.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68565c77e788832c921c8f2cc5d31acf