### PR TITLE
Fix memory growth by disposing HttpResponseMessage

### DIFF
--- a/SunatScraper.Infrastructure/Services/SunatClient.cs
+++ b/SunatScraper.Infrastructure/Services/SunatClient.cs
@@ -168,7 +168,7 @@ public sealed class SunatClient : ISunatClient, IDisposable
             if (j.HasValue) return j.ToString();
         }
 
-        var initRes = await _httpClient.GetAsync("cl-ti-itmrconsruc/FrameCriterioBusquedaWeb.jsp");
+        using var initRes = await _httpClient.GetAsync("cl-ti-itmrconsruc/FrameCriterioBusquedaWeb.jsp");
         if (initRes.IsSuccessStatusCode)
         {
             var body = await initRes.Content.ReadAsStringAsync();


### PR DESCRIPTION
## Summary
- dispose `HttpResponseMessage` when requesting FrameCriterioBusquedaWeb.jsp

## Testing
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6856a529c338832ca03d8175608e1501