### PR TITLE
Fix memory usage with using statements

### DIFF
--- a/SunatScraper.Infrastructure/Services/Security/CaptchaSolver.cs
+++ b/SunatScraper.Infrastructure/Services/Security/CaptchaSolver.cs
@@ -111,7 +111,10 @@ public class CaptchaSolver : IDisposable
         var png = await res.Content.ReadAsByteArrayAsync();
 #endif
         var tmp = Path.GetTempFileName() + ".png";
-        await File.WriteAllBytesAsync(tmp, png);
+        await using (var fs = File.Create(tmp))
+        {
+            await fs.WriteAsync(png);
+        }
         Console.Write($"Captcha manual ({tmp}): ");
         var text = Console.ReadLine()!.Trim().ToUpper();
         try


### PR DESCRIPTION
## Summary
- keep temporary captcha file in a `using var` block
- remove the unsupported Tesseract method call

## Testing
- `dotnet build SunatScraper.sln`

------
https://chatgpt.com/codex/tasks/task_e_6856a93d695c832cad83bda449c44db9