### PR TITLE
Fix DOM reference leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore build outputs
+**/bin/
+**/obj/

--- a/SunatScraper.Infrastructure/Services/Parsing/DocumentHtmlParser.cs
+++ b/SunatScraper.Infrastructure/Services/Parsing/DocumentHtmlParser.cs
@@ -19,7 +19,7 @@ internal static class DocumentHtmlParser
         return HtmlParserCommon.ParseRucInfoAsync(html);
     }
 
-    internal static IEnumerable<SearchResultItem> ParseList(string html)
+    internal static IReadOnlyList<SearchResultItem> ParseList(string html)
     {
         return RucHtmlParser.ParseList(html);
     }

--- a/SunatScraper.Infrastructure/Services/Parsing/RucHtmlParser.cs
+++ b/SunatScraper.Infrastructure/Services/Parsing/RucHtmlParser.cs
@@ -26,7 +26,7 @@ internal static class RucHtmlParser
     /// <summary>
     /// Obtiene una colección de coincidencias desde la página de resultados de búsqueda.
     /// </summary>
-    internal static IEnumerable<SearchResultItem> ParseList(string html)
+    internal static IReadOnlyList<SearchResultItem> ParseList(string html)
     {
         return SearchListHtmlParser.ParseList(html);
     }

--- a/SunatScraper.Infrastructure/Services/Parsing/RucParser.cs
+++ b/SunatScraper.Infrastructure/Services/Parsing/RucParser.cs
@@ -24,7 +24,7 @@ public static class RucParser
     /// <summary>
     /// Obtiene la lista de resultados encontrados en el HTML.
     /// </summary>
-    public static IEnumerable<SearchResultItem> ParseList(string html, bool porDocumento = false)
+    public static IReadOnlyList<SearchResultItem> ParseList(string html, bool porDocumento = false)
     {
         return porDocumento ? DocumentHtmlParser.ParseList(html) : RucHtmlParser.ParseList(html);
     }

--- a/SunatScraper.Infrastructure/Services/Parsing/SearchListHtmlParser.cs
+++ b/SunatScraper.Infrastructure/Services/Parsing/SearchListHtmlParser.cs
@@ -12,12 +12,12 @@ using System.Text.RegularExpressions;
 /// </summary>
 internal static class SearchListHtmlParser
 {
-    internal static IEnumerable<SearchResultItem> ParseList(string html)
+    internal static IReadOnlyList<SearchResultItem> ParseList(string html)
     {
         var document = new HtmlDocument();
         document.LoadHtml(html);
 
-        return document.DocumentNode
+        var items = document.DocumentNode
             .SelectNodes("//a[contains(@class,'aRucs')]")
             ?.Select(anchor =>
             {
@@ -55,9 +55,12 @@ internal static class SearchListHtmlParser
 
                 return new SearchResultItem(rucNumber, razonSocial, ubicacion, estado);
             })
-            ?? Enumerable.Empty<SearchResultItem>();
+            ?.ToList()
+            ?? new List<SearchResultItem>();
+
+        return items;
     }
 
     internal static Task<IReadOnlyList<SearchResultItem>> ParseListAsync(string html) =>
-        Task.Run(() => (IReadOnlyList<SearchResultItem>)ParseList(html).ToList());
+        Task.Run(() => ParseList(html));
 }

--- a/SunatScraper.Infrastructure/Services/SunatClient.cs
+++ b/SunatScraper.Infrastructure/Services/SunatClient.cs
@@ -94,7 +94,7 @@ public sealed class SunatClient : ISunatClient, IDisposable
             throw new ArgumentException("Doc inválido");
 
         var html = await GetHtmlAsync("consPorTipdoc", ("tipdoc", tipo), ("nrodoc", numero));
-        var results = RucParser.ParseList(html, true).ToList();
+        var results = RucParser.ParseList(html, true);
         string? ubicacion = results.Count > 0 ? results[0].Ubicacion : null;
 
         if (results.Count > 0 && !string.IsNullOrWhiteSpace(results[0].Ruc))
@@ -120,7 +120,7 @@ public sealed class SunatClient : ISunatClient, IDisposable
             throw new ArgumentException("Doc inválido");
 
         var html = await GetHtmlAsync("consPorTipdoc", ("tipdoc", tipo), ("nrodoc", numero));
-        return (IReadOnlyList<SearchResultItem>)RucParser.ParseList(html, true).ToList();
+        return RucParser.ParseList(html, true);
     }
 
     /// <summary>
@@ -132,7 +132,7 @@ public sealed class SunatClient : ISunatClient, IDisposable
             throw new ArgumentException("Texto inválido");
 
         var html = await GetHtmlAsync("consPorRazonSoc", ("razSoc", query));
-        return (IReadOnlyList<SearchResultItem>)RucParser.ParseList(html).ToList();
+        return RucParser.ParseList(html);
     }
 
     /// <summary>
@@ -144,7 +144,7 @@ public sealed class SunatClient : ISunatClient, IDisposable
             throw new ArgumentException("Texto inválido");
 
         var html = await GetHtmlAsync("consPorRazonSoc", ("razSoc", query));
-        var results = RucParser.ParseList(html).ToList();
+        var results = RucParser.ParseList(html);
         string? ubicacion = results.Count > 0 ? results[0].Ubicacion : null;
 
         if (results.Count > 0 && !string.IsNullOrWhiteSpace(results[0].Ruc))


### PR DESCRIPTION
## Summary
- prevent DOM nodes from escaping parsing methods
- adjust API code to handle new return types
- ignore build outputs

## Testing
- `dotnet build SunatScraper.sln -nologo`

------
https://chatgpt.com/codex/tasks/task_e_6872cbc39a70832c995eb9dc3eed0d78