### PR TITLE
Improve memory usage with streaming

### DIFF
--- a/SunatScraper.Infrastructure/Services/SunatClient.cs
+++ b/SunatScraper.Infrastructure/Services/SunatClient.cs
@@ -274,8 +274,9 @@ public sealed class SunatClient : ISunatClient, IDisposable
     private static async Task<string> ReadHtmlAsync(HttpResponseMessage res)
     {
         res.EnsureSuccessStatusCode();
-        var html = Encoding.GetEncoding("ISO-8859-1").GetString(await res.Content.ReadAsByteArrayAsync());
-        return html;
+        using var stream = await res.Content.ReadAsStreamAsync();
+        using var reader = new StreamReader(stream, Encoding.GetEncoding("ISO-8859-1"));
+        return await reader.ReadToEndAsync();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- process HTTP content using streams
- stream captcha responses to temp files

## Testing
- `dotnet build SunatScraper.sln -v minimal`
- `dotnet test SunatScraper.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6872d0cc5240832c82fdb21213a46ee8