### PR TITLE
Refactor API to use MVC controller

### DIFF
--- a/SunatScraper.Api/Controllers/SunatController.cs
+++ b/SunatScraper.Api/Controllers/SunatController.cs
@@ -1,0 +1,144 @@
+using Microsoft.AspNetCore.Mvc;
+using SunatScraper.Domain;
+using SunatScraper.Domain.Models;
+
+namespace SunatScraper.Api.Controllers;
+
+[ApiController]
+[Route("")]
+public sealed class SunatController : ControllerBase
+{
+    private readonly ISunatClient _client;
+
+    public SunatController(ISunatClient client)
+    {
+        _client = client;
+    }
+
+    [HttpGet]
+    public string Root() => "SUNAT RUC API ok";
+
+    [HttpGet("ruc/{ruc}")]
+    public async Task<ActionResult<RucInfo>> GetByRuc(string ruc)
+    {
+        try
+        {
+            var info = await _client.GetByRucAsync(ruc);
+            if (string.IsNullOrWhiteSpace(info.Ruc))
+                return NotFound(new { Mensaje = "Registro no encontrado" });
+            return Ok(info);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { Mensaje = ex.Message });
+        }
+        catch (HttpRequestException)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable,
+                new { Mensaje = "No se obtuvo respuesta del portal de SUNAT" });
+        }
+    }
+
+    [HttpGet("rucs")]
+    public async Task<ActionResult<IReadOnlyList<RucInfo>>> GetByRucs([FromQuery(Name="r")] string[] rucs)
+    {
+        try
+        {
+            var info = await _client.GetByRucsAsync(rucs);
+            return Ok(info);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { Mensaje = ex.Message });
+        }
+        catch (HttpRequestException)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable,
+                new { Mensaje = "No se obtuvo respuesta del portal de SUNAT" });
+        }
+    }
+
+    [HttpGet("doc/{tipo}/{numero}")]
+    public async Task<ActionResult<RucInfo>> GetByDocument(string tipo, string numero)
+    {
+        try
+        {
+            var info = await _client.GetByDocumentAsync(tipo, numero);
+            if (string.IsNullOrWhiteSpace(info.Ruc))
+                return NotFound(new { Mensaje = "Registro no encontrado" });
+            return Ok(info);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { Mensaje = ex.Message });
+        }
+        catch (HttpRequestException)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable,
+                new { Mensaje = "No se obtuvo respuesta del portal de SUNAT" });
+        }
+    }
+
+    [HttpGet("doc/{tipo}/{numero}/lista")]
+    public async Task<ActionResult<IReadOnlyList<SearchResultItem>>> SearchByDocument(string tipo, string numero)
+    {
+        try
+        {
+            var list = await _client.SearchByDocumentAsync(tipo, numero);
+            if (list.Count == 0)
+                return NotFound(new { Mensaje = "Registro no encontrado" });
+            return Ok(list);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { Mensaje = ex.Message });
+        }
+        catch (HttpRequestException)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable,
+                new { Mensaje = "No se obtuvo respuesta del portal de SUNAT" });
+        }
+    }
+
+    [HttpGet("rs/lista")]
+    public async Task<ActionResult<IReadOnlyList<SearchResultItem>>> SearchByName([FromQuery(Name="q")] string razonSocial)
+    {
+        try
+        {
+            var list = await _client.SearchByNameAsync(razonSocial);
+            if (list.Count == 0)
+                return NotFound(new { Mensaje = "Registro no encontrado" });
+            return Ok(list);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { Mensaje = ex.Message });
+        }
+        catch (HttpRequestException)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable,
+                new { Mensaje = "No se obtuvo respuesta del portal de SUNAT" });
+        }
+    }
+
+    [HttpGet("rs")]
+    public async Task<ActionResult<RucInfo>> GetByName([FromQuery(Name="q")] string razonSocial)
+    {
+        try
+        {
+            var info = await _client.GetByNameAsync(razonSocial);
+            if (string.IsNullOrWhiteSpace(info.Ruc))
+                return NotFound(new { Mensaje = "Registro no encontrado" });
+            return Ok(info);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { Mensaje = ex.Message });
+        }
+        catch (HttpRequestException)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable,
+                new { Mensaje = "No se obtuvo respuesta del portal de SUNAT" });
+        }
+    }
+}

--- a/SunatScraper.Api/Program.cs
+++ b/SunatScraper.Api/Program.cs
@@ -1,7 +1,6 @@
 // Punto de entrada principal de la API.
-// Aquí se configuran los servicios y se definen los endpoints HTTP.
+// Aquí se configuran los servicios y se registran los controladores.
 using Microsoft.AspNetCore.Http.Json;
-using Microsoft.AspNetCore.Mvc;
 using Serilog;
 using SunatScraper.Domain;
 using SunatScraper.Infrastructure.Services;
@@ -21,50 +20,13 @@ builder.Host.UseSerilog((ctx, lc) => lc.WriteTo.Console());
 builder.Services.AddSingleton<ISunatClient>(_ =>
     SunatClient.Create(builder.Configuration["Redis"]));
 
-builder.Services.ConfigureHttpJsonOptions(o =>
-    o.SerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull);
+builder.Services.AddControllers().AddJsonOptions(o =>
+    o.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull);
 
 var app = builder.Build();
 Console.WriteLine($"Listening on port {port}");
 
-// Endpoints HTTP
-app.MapGet("/", () => "SUNAT RUC API ok");
-
-// Consulta información detallada mediante número de RUC.
-app.MapGet(
-    "/ruc/{ruc}",
-    ([FromServices] ISunatClient client, string ruc) =>
-        ApiHelpers.Execute(async () => ApiHelpers.ToResult(await client.GetByRucAsync(ruc))));
-
-// Consulta múltiples RUCs en paralelo.
-app.MapGet(
-    "/rucs",
-    ([FromServices] ISunatClient client, [FromQuery(Name = "r")] string[] rucs) =>
-        ApiHelpers.Execute(async () => Results.Json(await client.GetByRucsAsync(rucs))));
-
-// Búsqueda por tipo y número de documento de identidad.
-app.MapGet(
-    "/doc/{tipo}/{numero}",
-    ([FromServices] ISunatClient client, string tipo, string numero) =>
-        ApiHelpers.Execute(async () => ApiHelpers.ToResult(await client.GetByDocumentAsync(tipo, numero))));
-
-// Devuelve la lista completa de coincidencias para un documento específico.
-app.MapGet(
-    "/doc/{tipo}/{numero}/lista",
-    ([FromServices] ISunatClient client, string tipo, string numero) =>
-        ApiHelpers.Execute(async () => ApiHelpers.ToResult(await client.SearchByDocumentAsync(tipo, numero))));
-
-// Obtiene las coincidencias de razón social sin datos de ubicación.
-app.MapGet(
-    "/rs/lista",
-    ([FromServices] ISunatClient client, [FromQuery(Name = "q")] string razonSocial) =>
-        ApiHelpers.Execute(async () => ApiHelpers.ToResult(await client.SearchByNameAsync(razonSocial))));
-
-// Consulta por razón social retornando ubicación cuando está disponible.
-app.MapGet(
-    "/rs",
-    ([FromServices] ISunatClient client, [FromQuery(Name = "q")] string razonSocial) =>
-        ApiHelpers.Execute(async () => ApiHelpers.ToResult(await client.GetByNameAsync(razonSocial))));
+app.MapControllers();
 
 app.Run();
 


### PR DESCRIPTION
## Summary
- create `SunatController` with endpoints for `/ruc/{ruc}`, `/rucs`, `/doc/{tipo}/{numero}`, etc.
- simplify `Program.cs` to register controllers and map them

## Testing
- `dotnet build SunatScraper.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6872d32055a8832cbce4f7ae08dd6d95