### PR TITLE
Fix memory leak by disposing parsed documents

### DIFF
--- a/SunatScraper.Infrastructure/Services/Parsing/HtmlParserCommon.cs
+++ b/SunatScraper.Infrastructure/Services/Parsing/HtmlParserCommon.cs
@@ -74,7 +74,7 @@ internal static class HtmlParserCommon
     internal static RucInfo ParseRucInfo(string html)
     {
         var parser = new HtmlParser();
-        var document = parser.ParseDocument(html);
+        using var document = parser.ParseDocument(html);
 
         var infoMap = BuildMap(document);
         var plainText = WebUtility.HtmlDecode(document.DocumentElement.TextContent);

--- a/SunatScraper.Infrastructure/Services/Parsing/SearchListHtmlParser.cs
+++ b/SunatScraper.Infrastructure/Services/Parsing/SearchListHtmlParser.cs
@@ -16,7 +16,7 @@ internal static class SearchListHtmlParser
     internal static IReadOnlyList<SearchResultItem> ParseList(string html)
     {
         var parser = new HtmlParser();
-        var document = parser.ParseDocument(html);
+        using var document = parser.ParseDocument(html);
 
         var items = document.QuerySelectorAll("a[class*=aRucs]")
             .Select(anchor =>


### PR DESCRIPTION
## Summary
- ensure parsed HTML documents are disposed when parsing RUC info and search lists

## Testing
- `dotnet build SunatScraper.sln`
- `dotnet format --verify-no-changes SunatScraper.sln`


------
https://chatgpt.com/codex/tasks/task_e_6876b7223468832c80264a3daab56714